### PR TITLE
Mttl 2217 - Changes after testing E2E against dev cluster 

### DIFF
--- a/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
@@ -8,9 +8,7 @@ using System;
 
 public class MockSchemaRegistry
 {
-    public string RegistryName { get; }
     public string SchemaArn { get; }
-    public string SchemaName { get; }
     public string SchemaDefinition { get; }
 
     private Mock<IAmazonGlue> _mockGlue { get; set; }
@@ -18,8 +16,6 @@ public class MockSchemaRegistry
     public MockSchemaRegistry(Mock<IAmazonGlue> mockGlue)
     {
         var fixture = new Fixture();
-        RegistryName = fixture.Create<string>();
-        SchemaName = fixture.Create<string>();
         SchemaArn = "arn:aws:glue:my-schema-registry";
         SchemaDefinition = SmallTenureSchema();
         _mockGlue = mockGlue;
@@ -34,9 +30,7 @@ public class MockSchemaRegistry
             SchemaId = new SchemaId()
             {
 
-                RegistryName = RegistryName,
                 SchemaArn = SchemaArn,
-                SchemaName = SchemaName
             }
         };
 
@@ -52,9 +46,7 @@ public class MockSchemaRegistry
         var getSchemaResponse = new GetSchemaResponse()
         {
             LatestSchemaVersion = getSchemaVersion.SchemaVersionNumber.VersionNumber,
-            RegistryName = RegistryName,
             SchemaArn = SchemaArn,
-            SchemaName = SchemaName
         };
 
         _mockGlue.Setup(x => x.GetSchemaAsync(It.Is<GetSchemaRequest>(x => MockGlueHelperMethods.CheckRequestsEquivalent(getSchemaRequest, x)), It.IsAny<CancellationToken>()))
@@ -69,8 +61,6 @@ public class MockSchemaRegistry
     private void SetSchemaEnvVariables()
     {
         Environment.SetEnvironmentVariable("SCHEMA_ARN", SchemaArn);
-        Environment.SetEnvironmentVariable("REGISTRY_NAME", RegistryName);
-        Environment.SetEnvironmentVariable("SCHEMA_NAME", SchemaName);
     }
     private string SmallTenureSchema()
     {
@@ -248,7 +238,7 @@ public class MockSchemaRegistry
                         ]
                     }
                 }
-            }
+            ]
         }";
     }
 }

--- a/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
@@ -27,37 +27,22 @@ public class MockSchemaRegistry
     {
         var mockGlueSdk = new Mock<IAmazonGlue>();
 
-        var getSchemaRequest = new GetSchemaRequest()
+        var getSchemaVersion = new GetSchemaVersionRequest()
         {
             SchemaId = new SchemaId()
             {
-
-                SchemaArn = SchemaArn,
-            }
-        };
-
-        var getSchemaVersion = new GetSchemaVersionRequest()
-        {
-            SchemaId = getSchemaRequest.SchemaId,
+                SchemaArn = SchemaArn
+            },
             SchemaVersionNumber = new SchemaVersionNumber()
             {
                 LatestVersion = true,
-                VersionNumber = 2
             }
         };
-        var getSchemaResponse = new GetSchemaResponse()
-        {
-            LatestSchemaVersion = getSchemaVersion.SchemaVersionNumber.VersionNumber,
-            SchemaArn = SchemaArn,
-        };
-
-        mockGlueSdk.Setup(x => x.GetSchemaAsync(It.Is<GetSchemaRequest>(x => MockGlueHelperMethods.CheckRequestsEquivalent(getSchemaRequest, x)), It.IsAny<CancellationToken>()))
-                       .ReturnsAsync(getSchemaResponse);
 
         mockGlueSdk.Setup(x => x.GetSchemaVersionAsync(
                 It.Is<GetSchemaVersionRequest>(x => MockGlueHelperMethods.CheckVersionRequestsEquivalent(getSchemaVersion, x)),
                 It.IsAny<CancellationToken>()
-            )).ReturnsAsync(new GetSchemaVersionResponse { SchemaDefinition = SchemaDefinition });
+            )).ReturnsAsync(new GetSchemaVersionResponse { SchemaDefinition = SchemaDefinition, VersionNumber = 2 });
         
         _mockGlue.Setup(x => x.GlueClient()).ReturnsAsync(mockGlueSdk.Object);
     }

--- a/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
@@ -43,7 +43,7 @@ public class MockSchemaRegistry
                 It.Is<GetSchemaVersionRequest>(x => MockGlueHelperMethods.CheckVersionRequestsEquivalent(getSchemaVersion, x)),
                 It.IsAny<CancellationToken>()
             )).ReturnsAsync(new GetSchemaVersionResponse { SchemaDefinition = SchemaDefinition, VersionNumber = 2 });
-        
+
         _mockGlue.Setup(x => x.GlueClient()).ReturnsAsync(mockGlueSdk.Object);
     }
 

--- a/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Fixtures/MockSchemaRegistry.cs
@@ -75,31 +75,64 @@ public class MockSchemaRegistry
     private string SmallTenureSchema()
     {
         return @"{
-        ""type"": ""record"",
-        ""namespace"": ""MMH"",
-        ""name"": ""TenureInformation"",
-        ""fields"": [
-            {
-                ""name"": ""Id"",
-                ""type"": ""string"",
-                ""logicalType"": ""uuid""
-            },
-            {
-                ""name"": ""PaymentReference"",
-                ""type"": ""string""
-            },
-            {
-                ""name"": ""SuccessionDate"",
-                ""type"": [""int"", ""null""],
-                ""logicalType"": ""date""
-            },
-            {
-                ""name"": ""HouseholdMembers"",
-                ""type"": {
-                    ""type"": ""array"",
-                    ""items"": {
-                        ""name"": ""HouseholdMember"",
+            ""type"": ""record"",
+            ""name"": ""TenureAPIChangeEvent"",
+            ""namespace"": ""MMH"",
+            ""fields"": [
+                {
+                    ""name"": ""Id"",
+                    ""type"": ""string"",
+                    ""logicalType"": ""uuid""
+                },
+                {
+                    ""name"": ""EventType"",
+                    ""type"": ""string""
+                },
+                {
+                    ""name"": ""SourceDomain"",
+                    ""type"": ""string""
+                },
+                {
+                    ""name"": ""SourceSystem"",
+                    ""type"": ""string""
+                },
+                {
+                    ""name"": ""Version"",
+                    ""type"": ""string""
+                },
+                {
+                    ""name"": ""CorrelationId"",
+                    ""type"": ""string"",
+                    ""logicalType"": ""uuid""
+                },
+                {
+                    ""name"": ""DateTime"",
+                    ""type"": ""int"",
+                    ""logicalType"": ""date""
+                },
+                {
+                    ""name"": ""User"",
+                    ""type"": {
                         ""type"": ""record"",
+                        ""name"": ""User"",
+                        ""fields"": [
+                            {
+                                ""name"": ""Name"",
+                                ""type"": ""string""
+                            },
+                            {
+                                ""name"": ""Email"",
+                                ""type"": ""string""
+                            }
+                        ]
+                    }
+                },
+                {
+                    ""name"": ""Tenure"",
+                    ""type"": {
+                        ""type"": ""record"",
+                        ""namespace"": ""MMH"",
+                        ""name"": ""TenureInformation"",
                         ""fields"": [
                             {
                                 ""name"": ""Id"",
@@ -107,89 +140,115 @@ public class MockSchemaRegistry
                                 ""logicalType"": ""uuid""
                             },
                             {
-                                ""name"": ""Type"",
-                                ""type"": {
-                                    ""name"": ""HouseholdMembersType"",
-                                    ""type"": ""enum"",
-                                    ""symbols"": [
-                                        ""Person"",
-                                        ""Organisation""
-                                    ]
-                                }
-                            },
-                            {
-                                ""name"": ""FullName"",
+                                ""name"": ""PaymentReference"",
                                 ""type"": ""string""
                             },
                             {
-                                ""name"": ""IsResponsible"",
-                                ""type"": ""boolean""
-                            },
-                            {
-                                ""name"": ""DateOfBirth"",
-                                ""type"": ""int"",
+                                ""name"": ""SuccessionDate"",
+                                ""type"": [""int"", ""null""],
                                 ""logicalType"": ""date""
                             },
                             {
-                                ""name"": ""PersonTenureType"",
+                                ""name"": ""HouseholdMembers"",
                                 ""type"": {
-                                    ""name"": ""PersonTenureType"",
-                                    ""type"": ""enum"",
-                                    ""symbols"": [
-                                        ""Tenant"",
-                                        ""Leaseholder"",
-                                        ""Freeholder"",
-                                        ""HouseholdMember"",
-                                        ""Occupant""
+                                    ""type"": ""array"",
+                                    ""items"": {
+                                        ""name"": ""HouseholdMember"",
+                                        ""type"": ""record"",
+                                        ""fields"": [
+                                            {
+                                                ""name"": ""Id"",
+                                                ""type"": ""string"",
+                                                ""logicalType"": ""uuid""
+                                            },
+                                            {
+                                                ""name"": ""Type"",
+                                                ""type"": {
+                                                    ""name"": ""HouseholdMembersType"",
+                                                    ""type"": ""enum"",
+                                                    ""symbols"": [
+                                                        ""Person"",
+                                                        ""Organisation""
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                ""name"": ""FullName"",
+                                                ""type"": ""string""
+                                            },
+                                            {
+                                                ""name"": ""IsResponsible"",
+                                                ""type"": ""boolean""
+                                            },
+                                            {
+                                                ""name"": ""DateOfBirth"",
+                                                ""type"": ""int"",
+                                                ""logicalType"": ""date""
+                                            },
+                                            {
+                                                ""name"": ""PersonTenureType"",
+                                                ""type"": {
+                                                    ""name"": ""PersonTenureType"",
+                                                    ""type"": ""enum"",
+                                                    ""symbols"": [
+                                                        ""Tenant"",
+                                                        ""Leaseholder"",
+                                                        ""Freeholder"",
+                                                        ""HouseholdMember"",
+                                                        ""Occupant""
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                ""name"": ""TenuredAsset"",
+                                ""type"": {
+                                    ""type"": ""record"",
+                                    ""name"": ""TenuredAsset"",
+                                    ""fields"": [
+                                        {
+                                            ""name"": ""Id"",
+                                            ""type"": ""string"",
+                                            ""logicalType"": ""uuid""
+                                        },
+                                        {
+                                            ""name"": ""Type"",
+                                            ""type"": [{
+                                                ""name"": ""TenuredAssetType"",
+                                                ""type"": ""enum"",
+                                                ""symbols"": [
+                                                    ""Block"",
+                                                    ""Concierge"",
+                                                    ""Dwelling"",
+                                                    ""LettableNonDwelling"",
+                                                    ""MediumRiseBlock"",
+                                                    ""NA"",
+                                                    ""TravellerSite""
+                                                ]
+                                            }, ""null""]
+                                        },
+                                        {
+                                            ""name"": ""FullAddress"",
+                                            ""type"": ""string""
+                                        },
+                                        {
+                                            ""name"": ""Uprn"",
+                                            ""type"": ""string""
+                                        },
+                                        {
+                                            ""name"": ""PropertyReference"",
+                                            ""type"": ""string""
+                                        }
                                     ]
                                 }
                             }
                         ]
                     }
                 }
-            },
-            {
-                ""name"": ""TenuredAsset"",
-                ""type"": {
-                    ""type"": ""record"",
-                    ""name"": ""TenuredAsset"",
-                    ""fields"": [
-                        {
-                            ""name"": ""Id"",
-                            ""type"": ""string"",
-                            ""logicalType"": ""uuid""
-                        },
-                        {
-                            ""name"": ""Type"",
-                            ""type"": [{
-                                ""name"": ""TenuredAssetType"",
-                                ""type"": ""enum"",
-                                ""symbols"": [
-                                    ""Block"",
-                                    ""Concierge"",
-                                    ""Dwelling"",
-                                    ""LettableNonDwelling"",
-                                    ""MediumRiseBlock"",
-                                    ""NA"",
-                                    ""TravellerSite""
-                                ]
-                            }, ""null""]
-                        },
-                        {
-                            ""name"": ""FullAddress"",
-                            ""type"": ""string""
-                        },
-                        {
-                            ""name"": ""Uprn"",
-                            ""type"": ""string""
-                        },
-                        {
-                            ""name"": ""PropertyReference"",
-                            ""type"": ""string""
-                        }
-                    ]
-                }
             }
-        ]}";
+        }";
     }
 }

--- a/MtfhReportingDataListener.Tests/E2ETests/Steps/BaseSteps.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Steps/BaseSteps.cs
@@ -4,13 +4,13 @@ using Amazon.Lambda.TestUtilities;
 using AutoFixture;
 using MtfhReportingDataListener.Boundary;
 using MtfhReportingDataListener.Infrastructure;
+using MtfhReportingDataListener.Factories;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
-using Amazon.Glue;
 
 namespace MtfhReportingDataListener.Tests.E2ETests.Steps
 {
@@ -43,14 +43,14 @@ namespace MtfhReportingDataListener.Tests.E2ETests.Steps
                            .Create();
         }
 
-        protected async Task<SQSEvent.SQSMessage> TriggerFunction(Guid id, IAmazonGlue glue)
+        protected async Task<SQSEvent.SQSMessage> TriggerFunction(Guid id, IGlueFactory glue)
         {
             var snsEvent = CreateEvent(id);
             var message = CreateMessage(snsEvent);
             return await TriggerFunction(message, glue).ConfigureAwait(false);
         }
 
-        protected async Task<SQSEvent.SQSMessage> TriggerFunction(SQSEvent.SQSMessage message, IAmazonGlue glue)
+        protected async Task<SQSEvent.SQSMessage> TriggerFunction(SQSEvent.SQSMessage message, IGlueFactory glue)
         {
             var mockLambdaLogger = new Mock<ILambdaLogger>();
             ILambdaContext lambdaContext = new TestLambdaContext()

--- a/MtfhReportingDataListener.Tests/E2ETests/Steps/TenureUpdatedUseCaseSteps.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Steps/TenureUpdatedUseCaseSteps.cs
@@ -71,8 +71,9 @@ namespace MtfhReportingDataListener.Tests.E2ETests.Steps
             }
         }
 
-        private void CheckRecord(GenericRecord receivedRecord, TenureResponseObject tenure)
+        private void CheckRecord(GenericRecord record, TenureResponseObject tenure)
         {
+            var receivedRecord = (GenericRecord) record["Tenure"];
             receivedRecord["Id"].Should().Be(tenure.Id.ToString());
             receivedRecord["PaymentReference"].Should().Be(tenure.PaymentReference);
             receivedRecord["SuccessionDate"].Should().Be((int?) (tenure.SuccessionDate?.Subtract(new DateTime(1970, 1, 1)))?.TotalSeconds);

--- a/MtfhReportingDataListener.Tests/E2ETests/Steps/TenureUpdatedUseCaseSteps.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Steps/TenureUpdatedUseCaseSteps.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Hackney.Shared.Tenure.Boundary.Response;
 using MtfhReportingDataListener.Gateway;
 using MtfhReportingDataListener.Infrastructure.Exceptions;
+using MtfhReportingDataListener.Factories;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -25,7 +26,7 @@ namespace MtfhReportingDataListener.Tests.E2ETests.Steps
             _eventType = EventTypes.TenureUpdatedEvent;
         }
 
-        public async Task WhenTheFunctionIsTriggered(Guid id, IAmazonGlue glue)
+        public async Task WhenTheFunctionIsTriggered(Guid id, IGlueFactory glue)
         {
             TheMessage = await TriggerFunction(id, glue).ConfigureAwait(false);
         }

--- a/MtfhReportingDataListener.Tests/E2ETests/Stories/TenureUpdatedTests.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Stories/TenureUpdatedTests.cs
@@ -1,8 +1,6 @@
 using MtfhReportingDataListener.Tests.E2ETests.Fixtures;
 using MtfhReportingDataListener.Tests.E2ETests.Steps;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using TestStack.BDDfy;
 using Xunit;
 using Moq;

--- a/MtfhReportingDataListener.Tests/E2ETests/Stories/TenureUpdatedTests.cs
+++ b/MtfhReportingDataListener.Tests/E2ETests/Stories/TenureUpdatedTests.cs
@@ -1,10 +1,10 @@
 using MtfhReportingDataListener.Tests.E2ETests.Fixtures;
 using MtfhReportingDataListener.Tests.E2ETests.Steps;
+using MtfhReportingDataListener.Factories;
 using System;
 using TestStack.BDDfy;
 using Xunit;
 using Moq;
-using Amazon.Glue;
 
 namespace MtfhReportingDataListener.Tests.E2ETests.Stories
 {
@@ -19,14 +19,14 @@ namespace MtfhReportingDataListener.Tests.E2ETests.Stories
         private readonly MockSchemaRegistry _schemaRegistry;
         private readonly TenureUpdatedUseCaseSteps _steps;
         private readonly MockApplicationFactory _appFactory;
-        private readonly Mock<IAmazonGlue> _mockGlue;
+        private readonly Mock<IGlueFactory> _mockGlue;
 
         public TenureUpdatedTests(MockApplicationFactory appFactory)
         {
             _tenureFixture = new TenureFixture();
             _appFactory = appFactory;
             _steps = new TenureUpdatedUseCaseSteps();
-            _mockGlue = new Mock<IAmazonGlue>();
+            _mockGlue = new Mock<IGlueFactory>();
             _schemaRegistry = new MockSchemaRegistry(_mockGlue);
         }
 

--- a/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
+++ b/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
@@ -3,6 +3,7 @@ using Amazon.Glue.Model;
 using Moq;
 using MtfhReportingDataListener.Gateway;
 using MtfhReportingDataListener.Gateway.Interfaces;
+using MtfhReportingDataListener.Factories;
 using Xunit;
 using System.Threading.Tasks;
 using System.Threading;
@@ -22,7 +23,9 @@ namespace MtfhReportingDataListener.Tests.Gateway
         public GlueGatewayTests()
         {
             _mockAmazonGlue = new Mock<IAmazonGlue>();
-            _gateway = new GlueGateway(_mockAmazonGlue.Object);
+            var mockGlueWrapper = new Mock<IGlueFactory>();
+            mockGlueWrapper.Setup(x => x.GlueClient()).ReturnsAsync(_mockAmazonGlue.Object);
+            _gateway = new GlueGateway(mockGlueWrapper.Object);
         }
 
 

--- a/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
+++ b/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
@@ -33,10 +33,7 @@ namespace MtfhReportingDataListener.Tests.Gateway
             {
                 SchemaId = new SchemaId()
                 {
-
-                    RegistryName = "TenureSchema",
                     SchemaArn = "arn:aws:glue:mmh",
-                    SchemaName = "MMH"
                 }
             };
             var getSchemaResponse = _fixture.Create<GetSchemaResponse>();
@@ -47,7 +44,7 @@ namespace MtfhReportingDataListener.Tests.Gateway
                     It.IsAny<CancellationToken>()
                 )).ReturnsAsync(new GetSchemaVersionResponse { SchemaDefinition = "schema" });
 
-            await _gateway.GetSchema("TenureSchema", "arn:aws:glue:mmh", "MMH").ConfigureAwait(false);
+            await _gateway.GetSchema("arn:aws:glue:mmh").ConfigureAwait(false);
             _mockAmazonGlue.Verify();
         }
 
@@ -91,7 +88,7 @@ namespace MtfhReportingDataListener.Tests.Gateway
                 )
             ).ReturnsAsync(response);
 
-            var schemaDetails = await _gateway.GetSchema("TenureSchema", "arn:aws:glue:mmh", "MMH").ConfigureAwait(false);
+            var schemaDetails = await _gateway.GetSchema("arn:aws:glue:mmh").ConfigureAwait(false);
 
             var expectedSchemaResponse = new SchemaResponse
             {

--- a/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
+++ b/MtfhReportingDataListener.Tests/Gateway/GlueGatewayTests.cs
@@ -28,61 +28,28 @@ namespace MtfhReportingDataListener.Tests.Gateway
             _gateway = new GlueGateway(mockGlueWrapper.Object);
         }
 
-
-        [Fact]
-        public async Task VerifyTheSchemaDetailsAreRetrievedFromGlue()
-        {
-            var getSchemaRequest = new GetSchemaRequest()
-            {
-                SchemaId = new SchemaId()
-                {
-                    SchemaArn = "arn:aws:glue:mmh",
-                }
-            };
-            var getSchemaResponse = _fixture.Create<GetSchemaResponse>();
-            _mockAmazonGlue.Setup(x => x.GetSchemaAsync(It.Is<GetSchemaRequest>(x => MockGlueHelperMethods.CheckRequestsEquivalent(getSchemaRequest, x)), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(getSchemaResponse).Verifiable();
-            _mockAmazonGlue.Setup(x => x.GetSchemaVersionAsync(
-                    It.IsAny<GetSchemaVersionRequest>(),
-                    It.IsAny<CancellationToken>()
-                )).ReturnsAsync(new GetSchemaVersionResponse { SchemaDefinition = "schema" });
-
-            await _gateway.GetSchema("arn:aws:glue:mmh").ConfigureAwait(false);
-            _mockAmazonGlue.Verify();
-        }
-
         [Theory]
         [InlineData("goodnight moon", 4)]
         [InlineData("hello world", 7)]
         public async Task VerifyGettingTheSchemaStringForTheLatestVersion(string schema, int versionId)
         {
-            var getSchemaResponse = new GetSchemaResponse()
-            {
-                LatestSchemaVersion = versionId,
-                RegistryName = "TenureSchema",
-                SchemaArn = "arn:aws:glue:mmh",
-                SchemaName = "MMH"
-            };
-
             var expectedRequest = new GetSchemaVersionRequest
             {
                 SchemaId = new SchemaId()
                 {
-                    RegistryName = "TenureSchema",
                     SchemaArn = "arn:aws:glue:mmh",
-                    SchemaName = "MMH"
                 },
                 SchemaVersionNumber = new SchemaVersionNumber
                 {
                     LatestVersion = true,
-                    VersionNumber = versionId
                 }
             };
 
-            _mockAmazonGlue.Setup(x => x.GetSchemaAsync(It.IsAny<GetSchemaRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(getSchemaResponse);
-
-            var response = new GetSchemaVersionResponse { SchemaDefinition = schema };
+            var response = new GetSchemaVersionResponse
+            {
+                SchemaDefinition = schema,
+                VersionNumber = versionId
+            };
 
             _mockAmazonGlue.Setup(x =>
                 x.GetSchemaVersionAsync(

--- a/MtfhReportingDataListener.Tests/Helper/MockGlueHelperMethods.cs
+++ b/MtfhReportingDataListener.Tests/Helper/MockGlueHelperMethods.cs
@@ -1,7 +1,4 @@
 using Amazon.Glue.Model;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MtfhReportingDataListener.Tests.Helper
 {
@@ -10,15 +7,11 @@ namespace MtfhReportingDataListener.Tests.Helper
 
         public static bool CheckRequestsEquivalent(GetSchemaRequest expectedRequest, GetSchemaRequest receivedRequest)
         {
-            return receivedRequest.SchemaId.RegistryName == expectedRequest.SchemaId.RegistryName
-                && receivedRequest.SchemaId.SchemaArn == expectedRequest.SchemaId.SchemaArn
-                && receivedRequest.SchemaId.SchemaName == expectedRequest.SchemaId.SchemaName;
+            return receivedRequest.SchemaId.SchemaArn == expectedRequest.SchemaId.SchemaArn;
         }
         public static bool CheckVersionRequestsEquivalent(GetSchemaVersionRequest expectedRequest, GetSchemaVersionRequest receivedRequest)
         {
-            return receivedRequest.SchemaId.RegistryName == expectedRequest.SchemaId.RegistryName
-                && receivedRequest.SchemaId.SchemaArn == expectedRequest.SchemaId.SchemaArn
-                && receivedRequest.SchemaId.SchemaName == expectedRequest.SchemaId.SchemaName
+            return receivedRequest.SchemaId.SchemaArn == expectedRequest.SchemaId.SchemaArn
                 && receivedRequest.SchemaVersionNumber.LatestVersion == expectedRequest.SchemaVersionNumber.LatestVersion
                 && receivedRequest.SchemaVersionNumber.VersionNumber == expectedRequest.SchemaVersionNumber.VersionNumber;
         }

--- a/MtfhReportingDataListener.Tests/UseCase/TenureUpdatedUseCaseTests.cs
+++ b/MtfhReportingDataListener.Tests/UseCase/TenureUpdatedUseCaseTests.cs
@@ -164,11 +164,10 @@ namespace MtfhReportingDataListener.Tests.UseCase
                 ]
             }";
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, _tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, _tenure);
 
             Assert.Equal(_tenure.Id.ToString(), receivedRecord["Id"]);
         }
-
 
         [Fact]
         public void BuildTenureRecordCanSetMultipleStringsToAGenericRecord()
@@ -189,7 +188,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
                 ]
             }";
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, _tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, _tenure);
 
             Assert.Equal(_tenure.Id.ToString(), receivedRecord["Id"]);
             Assert.Equal(_tenure.PaymentReference, receivedRecord["PaymentReference"]);
@@ -217,7 +216,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
             var tenure = _tenure;
             tenure.SuccessionDate = new DateTime(1970, 01, 02);
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, tenure);
 
             Assert.Equal(86400, receivedRecord["SuccessionDate"]);
         }
@@ -243,7 +242,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
 
             var fieldValue = GetFieldValueFromStringName<bool>(nullableBoolFieldName, _tenure);
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, _tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, _tenure);
 
             Assert.Equal(_tenure.IsActive, receivedRecord["IsActive"]);
             Assert.Equal(fieldValue, receivedRecord[nullableBoolFieldName]);
@@ -271,7 +270,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
                     ]
                 }";
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, _tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, _tenure);
             var receivedTenureType = (GenericRecord) receivedRecord["TenureType"];
 
             Assert.Equal(_tenure.TenureType.Code, receivedTenureType["Code"]);
@@ -307,7 +306,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
             var tenure = _tenure;
             tenure.HouseholdMembers = new List<HouseholdMembers> { tenure.HouseholdMembers.First() };
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, tenure);
             receivedRecord["HouseholdMembers"].Should().BeOfType<GenericRecord[]>();
 
             var firstRecord = ((GenericRecord[]) receivedRecord["HouseholdMembers"]).ToList().First();
@@ -355,7 +354,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
 
             var tenure = _tenure;
             tenure.HouseholdMembers = new List<HouseholdMembers> { tenure.HouseholdMembers.First() };
-            var receivedRecord = _sut.BuildTenureRecord(schema, tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, tenure);
             var receivedHouseholdMember = ((GenericRecord[]) receivedRecord["HouseholdMembers"])[0];
 
             receivedHouseholdMember["Id"].Should().Be(_tenure.HouseholdMembers.First().Id.ToString());
@@ -402,7 +401,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
                 ]
             }";
 
-            var receivedRecord = _sut.BuildTenureRecord(schema, _tenure);
+            var receivedRecord = ExecuteBuildTenureRecord(schema, _tenure);
             var receivedRecordEnum = (GenericEnum) ((GenericRecord) receivedRecord["TenuredAsset"])["Type"];
             receivedRecord["TenuredAsset"].Should().BeOfType<GenericRecord>();
 
@@ -425,7 +424,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
                 ]
             }";
 
-            Func<GenericRecord> receivedRecord = () => _sut.BuildTenureRecord(schema, _tenure);
+            Func<GenericRecord> receivedRecord = () => ExecuteBuildTenureRecord(schema, _tenure);
 
             receivedRecord.Should().NotThrow<NullReferenceException>();
         }
@@ -433,6 +432,11 @@ namespace MtfhReportingDataListener.Tests.UseCase
         private T GetFieldValueFromStringName<T>(string fieldName, TenureResponseObject tenure)
         {
             return (T) typeof(TenureResponseObject).GetProperty(fieldName).GetValue(tenure);
+        }
+
+        private GenericRecord ExecuteBuildTenureRecord(string schema, TenureResponseObject tenure)
+        {
+            return _sut.BuildTenureRecord(schema, _tenure);
         }
     }
 }

--- a/MtfhReportingDataListener.Tests/UseCase/TenureUpdatedUseCaseTests.cs
+++ b/MtfhReportingDataListener.Tests/UseCase/TenureUpdatedUseCaseTests.cs
@@ -114,12 +114,8 @@ namespace MtfhReportingDataListener.Tests.UseCase
 
             var schemaArn = "arn:aws:glue:blah";
             Environment.SetEnvironmentVariable("SCHEMA_ARN", schemaArn);
-            var registryName = _fixture.Create<string>();
-            Environment.SetEnvironmentVariable("REGISTRY_NAME", registryName);
-            var schemaName = _fixture.Create<string>();
-            Environment.SetEnvironmentVariable("SCHEMA_NAME", schemaName);
 
-            _mockGlue.Setup(x => x.GetSchema(registryName, schemaArn, schemaName)).ReturnsAsync(mockSchemaResponse).Verifiable();
+            _mockGlue.Setup(x => x.GetSchema(schemaArn)).ReturnsAsync(mockSchemaResponse).Verifiable();
 
             await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
             _mockGlue.Verify();
@@ -143,7 +139,7 @@ namespace MtfhReportingDataListener.Tests.UseCase
                 ]
                 }"
             };
-            _mockGlue.Setup(x => x.GetSchema(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(mockSchemaResponse);
+            _mockGlue.Setup(x => x.GetSchema(It.IsAny<string>())).ReturnsAsync(mockSchemaResponse);
 
             await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
             _mockKafka.Verify(x => x.SendDataToKafka("mtfh-reporting-data-listener", It.IsAny<GenericRecord>(), It.IsAny<Schema>()), Times.Once);

--- a/MtfhReportingDataListener/BaseFunction.cs
+++ b/MtfhReportingDataListener/BaseFunction.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
-using Amazon.Glue;
+using MtfhReportingDataListener.Factories;
 
 namespace MtfhReportingDataListener
 {
@@ -22,16 +22,16 @@ namespace MtfhReportingDataListener
     public abstract class BaseFunction
     {
         protected readonly static JsonSerializerOptions _jsonOptions = JsonOptions.CreateJsonOptions();
-        protected IAmazonGlue Glue { get; set; }
+        protected IGlueFactory Glue { get; set; }
 
         protected IConfigurationRoot Configuration { get; private set; }
 
         protected IServiceProvider ServiceProvider { get; private set; }
         protected ILogger Logger { get; private set; }
 
-        internal BaseFunction(IAmazonGlue glue = null)
+        internal BaseFunction(IGlueFactory glue = null)
         {
-            Glue = glue ?? new AmazonGlueClient();
+            Glue = glue ?? new GlueFactory();
             Construct();
         }
 

--- a/MtfhReportingDataListener/Domain/TenureChangeEvent.cs
+++ b/MtfhReportingDataListener/Domain/TenureChangeEvent.cs
@@ -1,0 +1,33 @@
+using System;
+using Hackney.Shared.Tenure.Boundary.Response;
+
+namespace MtfhReportingDataListener.Domain
+{
+    public class TenureChangeEvent
+    {
+        public Guid Id { get; set; }
+
+        public string EventType { get; set; }
+
+        public string SourceDomain { get; set; }
+
+        public string SourceSystem { get; set; }
+
+        public string Version { get; set; }
+
+        public Guid CorrelationId { get; set; }
+
+        public DateTime DateTime { get; set; }
+
+        public User User { get; set; }
+
+        public TenureResponseObject Tenure { get; set; }
+    }
+
+    public class User
+    {
+        public string Name { get; set;}
+
+        public string Email { get; set; }
+    }
+}

--- a/MtfhReportingDataListener/Domain/TenureChangeEvent.cs
+++ b/MtfhReportingDataListener/Domain/TenureChangeEvent.cs
@@ -26,7 +26,7 @@ namespace MtfhReportingDataListener.Domain
 
     public class User
     {
-        public string Name { get; set;}
+        public string Name { get; set; }
 
         public string Email { get; set; }
     }

--- a/MtfhReportingDataListener/Factories/GlueFactory.cs
+++ b/MtfhReportingDataListener/Factories/GlueFactory.cs
@@ -13,7 +13,7 @@ namespace MtfhReportingDataListener.Factories
             var stsClient = new AmazonSecurityTokenServiceClient();
             var assumeRoleReq = new AssumeRoleRequest()
             {
-                DurationSeconds = 3600,
+                DurationSeconds = 900,
                 RoleArn = Environment.GetEnvironmentVariable("ROLE_ARN_TO_ACCESS_DATAPLATFORM_GLUE_REGISTRY"),
                 RoleSessionName = "mtfh-tenure-api-events-streaming",
             };

--- a/MtfhReportingDataListener/Factories/GlueFactory.cs
+++ b/MtfhReportingDataListener/Factories/GlueFactory.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Amazon.Glue;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using System;
+
+namespace MtfhReportingDataListener.Factories
+{
+    public class GlueFactory : IGlueFactory
+    {
+        public async Task<IAmazonGlue> GlueClient()
+        {
+            var stsClient = new AmazonSecurityTokenServiceClient();
+            var assumeRoleReq = new AssumeRoleRequest()
+            {
+                DurationSeconds = 3600,
+                RoleArn = Environment.GetEnvironmentVariable("ROLE_ARN_TO_ACCESS_DATAPLATFORM_GLUE_REGISTRY"),
+                RoleSessionName = "mtfh-tenure-api-events-streaming",
+            };
+
+            var response = await stsClient.AssumeRoleAsync(assumeRoleReq);
+
+            var credentials = response.Credentials;
+            return new AmazonGlueClient(credentials);
+        }
+    }
+
+    public interface IGlueFactory
+    {
+        Task<IAmazonGlue> GlueClient();
+    }
+}

--- a/MtfhReportingDataListener/Gateway/GlueGateway.cs
+++ b/MtfhReportingDataListener/Gateway/GlueGateway.cs
@@ -1,4 +1,3 @@
-using Amazon.Glue;
 using MtfhReportingDataListener.Gateway.Interfaces;
 using MtfhReportingDataListener.Factories;
 using System.Threading.Tasks;
@@ -17,18 +16,6 @@ namespace MtfhReportingDataListener.Gateway
         public async Task<SchemaResponse> GetSchema(string schemaArn)
         {
             var glueClient = await _amazonGlue.GlueClient().ConfigureAwait(false);
-            var latestVersionNumber = await GetLastestSchemaVersionNumber(glueClient, schemaArn).ConfigureAwait(false);
-            var SchemaDefinition = await GetSchemaDefinition(glueClient, schemaArn, latestVersionNumber).ConfigureAwait(false);
-
-            return new SchemaResponse
-            {
-                Schema = SchemaDefinition,
-                VersionId = latestVersionNumber
-            };
-        }
-
-        private async Task<string> GetSchemaDefinition(IAmazonGlue glueClient, string schemaArn, long versionNumber)
-        {
             var schemaVersionRequest = new GetSchemaVersionRequest()
             {
                 SchemaId = new SchemaId()
@@ -37,29 +24,16 @@ namespace MtfhReportingDataListener.Gateway
                 },
                 SchemaVersionNumber = new SchemaVersionNumber()
                 {
-                    LatestVersion = true,
-                    VersionNumber = versionNumber
+                    LatestVersion = true
                 }
             };
-
             var schemaVersionResponse = await glueClient.GetSchemaVersionAsync(schemaVersionRequest).ConfigureAwait(false);
-            return schemaVersionResponse.SchemaDefinition;
-        }
 
-
-
-        private async Task<long> GetLastestSchemaVersionNumber(IAmazonGlue glueClient, string schemaArn)
-        {
-            var schemaRequest = new GetSchemaRequest()
+            return new SchemaResponse
             {
-                SchemaId = new SchemaId()
-                {
-                    SchemaArn = schemaArn,
-                }
+                Schema = schemaVersionResponse.SchemaDefinition,
+                VersionId = schemaVersionResponse.VersionNumber
             };
-
-            var getSchemaResponse = await glueClient.GetSchemaAsync(schemaRequest).ConfigureAwait(false);
-            return getSchemaResponse.LatestSchemaVersion;
         }
     }
 }

--- a/MtfhReportingDataListener/Gateway/GlueGateway.cs
+++ b/MtfhReportingDataListener/Gateway/GlueGateway.cs
@@ -13,10 +13,10 @@ namespace MtfhReportingDataListener.Gateway
             _amazonGlueClient = amazonGlueClient;
         }
 
-        public async Task<SchemaResponse> GetSchema(string registryName, string schemaArn, string schemaName)
+        public async Task<SchemaResponse> GetSchema(string schemaArn)
         {
-            var latestVersionNumber = await GetLastestSchemaVersionNumber(registryName, schemaArn, schemaName).ConfigureAwait(false);
-            var SchemaDefinition = await GetSchemaDefinition(registryName, schemaArn, schemaName, latestVersionNumber).ConfigureAwait(false);
+            var latestVersionNumber = await GetLastestSchemaVersionNumber(schemaArn).ConfigureAwait(false);
+            var SchemaDefinition = await GetSchemaDefinition(schemaArn, latestVersionNumber).ConfigureAwait(false);
 
             return new SchemaResponse
             {
@@ -25,17 +25,13 @@ namespace MtfhReportingDataListener.Gateway
             };
         }
 
-        private async Task<string> GetSchemaDefinition(string registryName, string schemaArn, string schemaName, long versionNumber)
+        private async Task<string> GetSchemaDefinition(string schemaArn, long versionNumber)
         {
             var schemaVersionRequest = new GetSchemaVersionRequest()
             {
                 SchemaId = new SchemaId()
                 {
-
-                    RegistryName = registryName,
                     SchemaArn = schemaArn,
-                    SchemaName = schemaName
-
                 },
                 SchemaVersionNumber = new SchemaVersionNumber()
                 {
@@ -50,17 +46,13 @@ namespace MtfhReportingDataListener.Gateway
 
 
 
-        private async Task<long> GetLastestSchemaVersionNumber(string registryName, string schemaArn, string schemaName)
+        private async Task<long> GetLastestSchemaVersionNumber(string schemaArn)
         {
             var schemaRequest = new GetSchemaRequest()
             {
                 SchemaId = new SchemaId()
                 {
-
-                    RegistryName = registryName,
                     SchemaArn = schemaArn,
-                    SchemaName = schemaName
-
                 }
             };
 

--- a/MtfhReportingDataListener/Gateway/Interfaces/IGlueGateway.cs
+++ b/MtfhReportingDataListener/Gateway/Interfaces/IGlueGateway.cs
@@ -4,7 +4,7 @@ namespace MtfhReportingDataListener.Gateway.Interfaces
 {
     public interface IGlueGateway
     {
-        Task<SchemaResponse> GetSchema(string registryName, string schemaArn, string schemaName);
+        Task<SchemaResponse> GetSchema(string schemaArn);
     }
 
     public class SchemaResponse

--- a/MtfhReportingDataListener/MtfhReportingDataListener.csproj
+++ b/MtfhReportingDataListener/MtfhReportingDataListener.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.0.0" />
     <PackageReference Include="AWSSDK.Glue" Version="3.7.10.6" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.108" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.3.0" />

--- a/MtfhReportingDataListener/SqsFunction.cs
+++ b/MtfhReportingDataListener/SqsFunction.cs
@@ -33,12 +33,10 @@ namespace MtfhReportingDataListener
         /// the AWS credentials will come from the IAM role associated with the function and the AWS region will be set to the
         /// region the Lambda function is executed in.
         /// </summary>
-        public SqsFunction() { }
-
-        /// <summary>
-        /// Constructor to be used by the E2E tests so that we can mock API calls to AWS Glue.
-        /// </summary>
-        public SqsFunction(IAmazonGlue glue) : base(glue) { }
+        /// <param name="glue">
+        /// This paramter will only be used in E2E tests so that we can mock out the glue SDK.
+        /// </param>
+        public SqsFunction(IGlueFactory glue = null) : base(glue) { }
 
         /// <summary>
         /// Use this method to perform any DI configuration required
@@ -55,8 +53,7 @@ namespace MtfhReportingDataListener
 
             services.AddApiGateway();
 
-            // register glue SDK
-            services.AddSingleton<IAmazonGlue>(Glue);
+            services.AddSingleton<IGlueFactory>(Glue);
             base.ConfigureServices(services);
         }
 

--- a/MtfhReportingDataListener/SqsFunction.cs
+++ b/MtfhReportingDataListener/SqsFunction.cs
@@ -15,7 +15,6 @@ using System.Threading.Tasks;
 using Amazon.Glue;
 using MtfhReportingDataListener.Factories;
 using Hackney.Core.Http;
-using Confluent.SchemaRegistry;
 using Microsoft.Extensions.Configuration;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.

--- a/MtfhReportingDataListener/SqsFunction.cs
+++ b/MtfhReportingDataListener/SqsFunction.cs
@@ -33,10 +33,14 @@ namespace MtfhReportingDataListener
         /// the AWS credentials will come from the IAM role associated with the function and the AWS region will be set to the
         /// region the Lambda function is executed in.
         /// </summary>
+        public SqsFunction () { }
+        /// <summary>
+        /// Contstructor used in E2E tests.
+        /// </summary>
         /// <param name="glue">
-        /// This paramter will only be used in E2E tests so that we can mock out the glue SDK.
+        /// This parameter allows us to provide a mock for the AWS glue SDK.
         /// </param>
-        public SqsFunction(IGlueFactory glue = null) : base(glue) { }
+        public SqsFunction(IGlueFactory glue) : base(glue) { }
 
         /// <summary>
         /// Use this method to perform any DI configuration required

--- a/MtfhReportingDataListener/SqsFunction.cs
+++ b/MtfhReportingDataListener/SqsFunction.cs
@@ -33,7 +33,7 @@ namespace MtfhReportingDataListener
         /// the AWS credentials will come from the IAM role associated with the function and the AWS region will be set to the
         /// region the Lambda function is executed in.
         /// </summary>
-        public SqsFunction () { }
+        public SqsFunction() { }
         /// <summary>
         /// Contstructor used in E2E tests.
         /// </summary>

--- a/MtfhReportingDataListener/UseCase/TenureUpdatedUseCase.cs
+++ b/MtfhReportingDataListener/UseCase/TenureUpdatedUseCase.cs
@@ -92,7 +92,6 @@ namespace MtfhReportingDataListener.UseCase
                         record.Add(field.Name, null);
                         return;
                     }
-
                     fieldSchema = GetNonNullablePartOfNullableSchema(field.Schema);
                     fieldType = fieldSchema.Tag;
                 }

--- a/MtfhReportingDataListener/UseCase/TenureUpdatedUseCase.cs
+++ b/MtfhReportingDataListener/UseCase/TenureUpdatedUseCase.cs
@@ -39,9 +39,7 @@ namespace MtfhReportingDataListener.UseCase
             if (tenure is null) throw new EntityNotFoundException<TenureResponseObject>(message.EntityId);
 
             var schemaArn = Environment.GetEnvironmentVariable("SCHEMA_ARN");
-            var registryName = Environment.GetEnvironmentVariable("REGISTRY_NAME");
-            var schemaName = Environment.GetEnvironmentVariable("SCHEMA_NAME");
-            var schema = await _glueGateway.GetSchema(registryName, schemaArn, schemaName).ConfigureAwait(false);
+            var schema = await _glueGateway.GetSchema(schemaArn).ConfigureAwait(false);
 
             var schemaWithMetadata = new Confluent.SchemaRegistry.Schema("tenure", 1, 1, schema.Schema);
             var tenureChangeEvent = new TenureChangeEvent

--- a/MtfhReportingDataListener/serverless.yml
+++ b/MtfhReportingDataListener/serverless.yml
@@ -26,8 +26,6 @@ functions:
       TenureApiToken: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-token}
       DATAPLATFORM_KAFKA_HOSTNAME: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-kafka-hostname}
       SCHEMA_ARN: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-tenure-schema-arn}
-      REGISTRY_NAME: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-schema-registry-name}
-      SCHEMA_NAME: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-tenure-schema-name}  
     events:
       ## Specify the parameter containing the queue arn used to trigget the lambda function here
       ## This will have been defined in the terraform configuration
@@ -100,6 +98,14 @@ resources:
                     - "sqs:SendMessage"
                     - "kms:Decrypt"
                   Resource: "*"
+          - PolicyName: glueSchemaRegistry
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "glue:Get*"
+                  Resource: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-tenure-schema-arn} 
 
 custom:
   vpc:

--- a/MtfhReportingDataListener/serverless.yml
+++ b/MtfhReportingDataListener/serverless.yml
@@ -26,6 +26,7 @@ functions:
       TenureApiToken: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-token}
       DATAPLATFORM_KAFKA_HOSTNAME: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-kafka-hostname}
       SCHEMA_ARN: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-tenure-schema-arn}
+      ROLE_ARN_TO_ACCESS_DATAPLATFORM_GLUE_REGISTRY: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-role-arn-to-access-glue-registry}
     events:
       ## Specify the parameter containing the queue arn used to trigget the lambda function here
       ## This will have been defined in the terraform configuration

--- a/MtfhReportingDataListener/serverless.yml
+++ b/MtfhReportingDataListener/serverless.yml
@@ -99,14 +99,14 @@ resources:
                     - "sqs:SendMessage"
                     - "kms:Decrypt"
                   Resource: "*"
-          - PolicyName: glueSchemaRegistry
+          - PolicyName: assumeGlueRole
             PolicyDocument:
               Version: '2012-10-17'
               Statement:
                 - Effect: Allow
                   Action:
-                    - "glue:Get*"
-                  Resource: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-tenure-schema-arn} 
+                    - "sts:AssumeRole"
+                  Resource: ${ssm:/housing-tl/${self:provider.stage}/dataplatform-role-arn-to-access-glue-registry}
 
 custom:
   vpc:


### PR DESCRIPTION
## Link to JIRA ticket

[Jira ticket](https://hackney.atlassian.net/browse/MTTL-2216)

## Describe this PR

### *What is the problem we're trying to solve*

We need change events from the tenure API streaming into the data platform.

### *What changes have we introduced*

- Added metadata surrounding the tenure entity in the message that is sent to Kafka. The metadata is everything that is received in the SQS message (e.g. API version, timestamp of change, user info).
 - Added a Glue factory which will get the credentials for a role to assume. This role will allow the lambda to access a schema that is stored in the data platform account. The factory has been created so that the glue SDK can easily be injected so we can mock out the SDK whilst testing. Also given the lambda execution role permissions to assume this role.
 - Previously, we were calling glue to get the latest version number then getting the schema description. It turns out that we had misread the documentation and you can in fact just use a flag when getting the schema that will get the latest one. In a future iteration, this version number will be tied to the version of the API.

#### _Checklist_

- [x] Updated end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Updated tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Further testing of the lambda.
