### PR TITLE
Add feature branch CCI workflow with Terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,21 @@ jobs:
     steps:
       - terraform-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  development:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -291,7 +291,7 @@ workflows:
           filters:
             branches:
               only: master
-  check-and-deploy-staging-and-production:
+  staging-and-production:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,36 @@ workflows:
               ignore:
                 - master
                 - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
   development:
     jobs:
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,24 @@ jobs:
           stage: "production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
   development:
     jobs:
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,12 +262,13 @@ jobs:
 workflows:
   development:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              only: master
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -281,16 +282,10 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-          filters:
-            branches:
-              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          filters:
-            branches:
-              only: master
   staging-and-production:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-preview:
+    description: "Gives a preview for Terraform configuration changes."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   deploy-lambda:
     description: "Deploys via Serverless"
     parameters:


### PR DESCRIPTION
# What:
 - Add Terraform preview steps to the feature branch workflow.

# Why:
 - To prevent accidental resource modification, downgrades, or destruction upon releasing new changes whilst having unforeseen Terraform drift.

# Notes:
 - Renamed workflows to have clearer names in terms of which branches or environments they represent.
 - Pipeline is failing at the build step, because during its setup a dependency that SonarCloud scanner needs fails to install. This will get addressed in the upcoming PR.