### PR TITLE
Fix `UPDATE_ROLLBACK_FAILED` when replacing the `dotnetcore3.1` deprecated runtime lambda with the newer `dotnet8` one.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,12 +269,12 @@ jobs:
     steps:
       - fix-stack-rollback:
           environment: "development"
-  fix-stack-rollback-development:
+  fix-stack-rollback-staging:
     executor: aws-cli/default
     steps:
       - fix-stack-rollback:
           environment: "staging"
-  fix-stack-rollback-development:
+  fix-stack-rollback-production:
     executor: aws-cli/default
     steps:
       - fix-stack-rollback:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,21 @@ jobs:
     steps:
       - terraform-preview:
           environment: "production"
+  fix-stack-rollback-development:
+    executor: aws-cli/default
+    steps:
+      - fix-stack-rollback:
+          environment: "development"
+  fix-stack-rollback-development:
+    executor: aws-cli/default
+    steps:
+      - fix-stack-rollback:
+          environment: "staging"
+  fix-stack-rollback-development:
+    executor: aws-cli/default
+    steps:
+      - fix-stack-rollback:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,19 +139,12 @@ commands:
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation list-stack-resources \
                 --stack-name "$CF_STACK_NAME" \
-                --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId' \
-                --no-paginate \
-              )
-
-            ALL_RESOURCES=$(aws cloudformation list-stack-resources \
-                --stack-name "$CF_STACK_NAME" \
-                --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED']' \
+                --query "StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId" \
                 --no-paginate \
                 --output json \
               )
 
             echo "*$FAILED_ROLLBACK_RESOURCES*"
-            echo "*$ALL_RESOURCES*"
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,10 +142,15 @@ commands:
                 --query "StackResources[?ResourceStatus == 'UPDATE_FAILED']" \
                 --no-paginate \
                 --output json \
-              )
-
+            )
             echo "Failing resources found:"
             echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId),\nFail Reason: \(.ResourceStatusReason).\n"'
+            
+            FAILED_RESOURCE_IDENTIFIERS=$( \
+              echo $FAILED_ROLLBACK_RESOURCES | \
+              jq -r '[.[].LogicalResourceId] | map("\"" + . + "\"") | join(" ")' \
+            )
+            echo "Failed ids: *$FAILED_RESOURCE_IDENTIFIERS*."
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,13 +138,23 @@ commands:
 
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation list-stack-resources \
-                --stack-name $CF_STACK_NAME \
+                --stack-name "$CF_STACK_NAME" \
                 --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId' \
                 --no-paginate \
                 --output text \
               )
-            
-            echo $FAILED_ROLLBACK_RESOURCES
+
+            # Test that credentials are configured
+            aws s3 ls
+
+            ALL_RESOURCES=$(aws cloudformation list-stack-resources \
+                --stack-name "$CF_STACK_NAME" \
+                --no-paginate \
+                --output json \
+              )
+
+            echo "*$FAILED_ROLLBACK_RESOURCES*"
+            echo "*$ALL_RESOURCES*"
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,10 +366,17 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
+      - permit-dev-cfs-rollback:
+          type: approval
+          requires:
+            - terraform-apply-development
+      - fix-stack-rollback-development:
+          requires:
+            - permit-dev-cfs-rollback
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
-            - terraform-apply-development
+            - fix-stack-rollback-development
   staging-and-production:
     jobs:
       - check-code-formatting:
@@ -409,10 +416,17 @@ workflows:
           filters:
             branches:
               only: release
+      - permit-stage-cfs-rollback:
+          type: approval
+          requires:
+            - terraform-apply-staging
+      - fix-stack-rollback-staging:
+          requires:
+            - permit-stage-cfs-rollback
       - deploy-to-staging:
           context: api-nuget-token-context
           requires:
-            - terraform-apply-staging
+            - fix-stack-rollback-staging
           filters:
             branches:
               only: release
@@ -456,10 +470,13 @@ workflows:
           filters:
             branches:
               only: release
+      - fix-stack-rollback-production:
+          requires:
+            - permit-production-release
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - permit-production-release
+            - fix-stack-rollback-production
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,8 +128,19 @@ commands:
       - aws-cli/install
       - run:
           command: |
-            echo "Performing manual upgrade for <<parameters.environment>> environment."
-            # TODO
+            echo "Performing manual CF stack rollback for <<parameters.environment>> environment."
+
+            TARGET_DATABASE_INSTANCE_ID='mtfh-reporting-data-<<parameters.environment>>'
+
+            FAILED_ROLLBACK_RESOURCES=$( \
+              aws cloudformation list-stack-resources \
+                --stack-name $TARGET_DATABASE_INSTANCE_ID \
+                --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId' \
+                --no-paginate \
+                --output text \
+              )
+            
+            echo $FAILED_ROLLBACK_RESOURCES
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,10 +144,8 @@ commands:
                 --output json \
               )
 
-            echo "*$FAILED_ROLLBACK_RESOURCES*"
-
             echo "Failing resources found:"
-            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId), Fail Reason: \(.ResourceStatusReason).'
+            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId), Fail Reason: \(.ResourceStatusReason)."'
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,9 @@ commands:
           command: |
             echo -e "Performing manual CF stack rollback for <<parameters.environment>> environment.\n"
 
+            # Needed in case of a retry to prevent processing the same action twice.
+            REQUEST_TOKEN="ContinueUpdateRollback-<<parameters.environment>>-9e28137b-c8c8-43d2-9389-afb0efccb623"
+
             SERVICE_NAME=$(find . -type f -name 'serverless.yml' -exec grep -oP 'service:\s+\K[\w-]+$' {} \;)
             echo -e "Service $SERVICE_NAME detected.\n"
 
@@ -144,13 +147,20 @@ commands:
                 --output json \
             )
             echo "Failing resources found:"
-            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId),\nFail Reason: \(.ResourceStatusReason).\n"'
+            echo $FAILED_ROLLBACK_RESOURCES | \
+            jq -r '.[] | "Resource: \(.LogicalResourceId),\nFail Reason: \(.ResourceStatusReason).\n"'
             
             FAILED_RESOURCE_IDENTIFIERS=$( \
               echo $FAILED_ROLLBACK_RESOURCES | \
-              jq -r '[.[].LogicalResourceId] | map("\"" + . + "\"") | join(" ")' \
+              jq -r '[.[].LogicalResourceId] | join(" ")' \
             )
             echo "Failed ids: *$FAILED_RESOURCE_IDENTIFIERS*."
+
+            # Perform manual CF stack rollback
+            aws cloudformation continue-update-rollback \
+              --stack-name $CF_STACK_NAME \
+              --resources-to-skip $FAILED_RESOURCE_IDENTIFIERS \
+              --client-request-token $REQUEST_TOKEN
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,12 +139,15 @@ commands:
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation describe-stack-resources \
                 --stack-name "$CF_STACK_NAME" \
-                --query "StackResources[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId" \
+                --query "StackResources[?ResourceStatus == 'UPDATE_FAILED']" \
                 --no-paginate \
                 --output json \
               )
 
             echo "*$FAILED_ROLLBACK_RESOURCES*"
+
+            echo "Failing resources found:"
+            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId), Fail Reason: \(.ResourceStatusReason).'
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@5.1.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,11 +130,12 @@ commands:
           command: |
             echo "Performing manual CF stack rollback for <<parameters.environment>> environment."
 
-            TARGET_DATABASE_INSTANCE_ID='mtfh-reporting-data-<<parameters.environment>>'
+            SERVICE_NAME=$(find . -type f -name 'serverless.yml' -exec grep -oP 'service:\s+\K[\w-]+$' {} \;)
+            CF_STACK_NAME='${SERVICE_NAME}-<<parameters.environment>>'
 
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation list-stack-resources \
-                --stack-name $TARGET_DATABASE_INSTANCE_ID \
+                --stack-name $CF_STACK_NAME \
                 --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId' \
                 --no-paginate \
                 --output text \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,14 @@ commands:
       - aws-cli/install
       - run:
           command: |
-            echo -e "Performing manual CF stack rollback for <<parameters.environment>> environment.\n"
+            get_stack_status() {
+              local stack_name="$1"
+              aws cloudformation describe-stacks \
+                --stack-name "$stack_name" \
+                --query 'Stacks[].StackStatus | [0]' \
+                --no-paginate \
+                --output text
+            }
 
             # Needed in case of a retry to prevent processing the same action twice.
             REQUEST_TOKEN="ContinueUpdateRollback-<<parameters.environment>>-9e28137b-c8c8-43d2-9389-afb0efccb623"
@@ -137,6 +144,18 @@ commands:
             echo -e "Service $SERVICE_NAME detected.\n"
 
             CF_STACK_NAME="${SERVICE_NAME}-<<parameters.environment>>"
+            echo -e "Checking $CF_STACK_NAME stack's status.\n"
+
+            STACK_STATUS=$(get_stack_status "$CF_STACK_NAME")
+            if [[ "$STACK_STATUS" != "UPDATE_ROLLBACK_FAILED" ]]; then
+              echo "Stack hasn't experienced rollback failure yet!"
+              exit 0
+            fi
+
+            # Debug/failsafe sleep
+            sleep 20s
+
+            echo -e "CF stack is confirmed to have failed rollback. Performing manual one.\n"
             echo -e "Searching $CF_STACK_NAME resources for failures...\n"
 
             FAILED_ROLLBACK_RESOURCES=$( \
@@ -154,9 +173,10 @@ commands:
               echo $FAILED_ROLLBACK_RESOURCES | \
               jq -r '[.[].LogicalResourceId] | join(" ")' \
             )
-            echo "Failed ids: *$FAILED_RESOURCE_IDENTIFIERS*."
+            echo "Failed ids: *$FAILED_RESOURCE_IDENTIFIERS*.\n"
 
             # Perform manual CF stack rollback
+            echo "Trigger continuation of the $CF_STACK_NAME rollback whilst excluding failed resources."
             aws cloudformation continue-update-rollback \
               --stack-name $CF_STACK_NAME \
               --resources-to-skip $FAILED_RESOURCE_IDENTIFIERS \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
             echo "Performing manual CF stack rollback for <<parameters.environment>> environment."
 
             SERVICE_NAME=$(find . -type f -name 'serverless.yml' -exec grep -oP 'service:\s+\K[\w-]+$' {} \;)
-            CF_STACK_NAME='${SERVICE_NAME}-<<parameters.environment>>'
+            CF_STACK_NAME="${SERVICE_NAME}-<<parameters.environment>>"
 
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation list-stack-resources \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,13 +128,13 @@ commands:
       - aws-cli/install
       - run:
           command: |
-            echo "Performing manual CF stack rollback for <<parameters.environment>> environment."
+            echo -e "Performing manual CF stack rollback for <<parameters.environment>> environment.\n"
 
             SERVICE_NAME=$(find . -type f -name 'serverless.yml' -exec grep -oP 'service:\s+\K[\w-]+$' {} \;)
-            echo "Service $SERVICE_NAME detected."
+            echo -e "Service $SERVICE_NAME detected.\n"
 
             CF_STACK_NAME="${SERVICE_NAME}-<<parameters.environment>>"
-            echo "Searching $CF_STACK_NAME resources for failures."
+            echo -e "Searching $CF_STACK_NAME resources for failures...\n"
 
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation describe-stack-resources \
@@ -145,7 +145,7 @@ commands:
               )
 
             echo "Failing resources found:"
-            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId), Fail Reason: \(.ResourceStatusReason)."'
+            echo $FAILED_ROLLBACK_RESOURCES | jq -r '.[] | "Resource: \(.LogicalResourceId),\nFail Reason: \(.ResourceStatusReason).\n"'
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,14 +141,11 @@ commands:
                 --stack-name "$CF_STACK_NAME" \
                 --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId' \
                 --no-paginate \
-                --output text \
               )
-
-            # Test that credentials are configured
-            aws s3 ls
 
             ALL_RESOURCES=$(aws cloudformation list-stack-resources \
                 --stack-name "$CF_STACK_NAME" \
+                --query 'StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED']' \
                 --no-paginate \
                 --output json \
               )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,10 @@ commands:
             echo "Performing manual CF stack rollback for <<parameters.environment>> environment."
 
             SERVICE_NAME=$(find . -type f -name 'serverless.yml' -exec grep -oP 'service:\s+\K[\w-]+$' {} \;)
+            echo "Service $SERVICE_NAME detected."
+
             CF_STACK_NAME="${SERVICE_NAME}-<<parameters.environment>>"
+            echo "Searching $CF_STACK_NAME resources for failures."
 
             FAILED_ROLLBACK_RESOURCES=$( \
               aws cloudformation list-stack-resources \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,20 @@ commands:
             terraform init
             terraform plan
           name: terraform preview
+  fix-stack-rollback:
+    description: "Fixes the CloudFormation UPDATE_ROLLBACK_FAILED when upgrading lambda from an unsupported runtime."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - aws-cli/install
+      - run:
+          command: |
+            echo "Performing manual upgrade for <<parameters.environment>> environment."
+            # TODO
+          name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,9 @@ commands:
             echo "Searching $CF_STACK_NAME resources for failures."
 
             FAILED_ROLLBACK_RESOURCES=$( \
-              aws cloudformation list-stack-resources \
+              aws cloudformation describe-stack-resources \
                 --stack-name "$CF_STACK_NAME" \
-                --query "StackResourceSummaries[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId" \
+                --query "StackResources[?ResourceStatus == 'UPDATE_FAILED'].LogicalResourceId" \
                 --no-paginate \
                 --output json \
               )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,11 +176,23 @@ commands:
             echo "Failed ids: *$FAILED_RESOURCE_IDENTIFIERS*.\n"
 
             # Perform manual CF stack rollback
-            echo "Trigger continuation of the $CF_STACK_NAME rollback whilst excluding failed resources."
+            echo -e "Trigger continuation of the $CF_STACK_NAME rollback whilst excluding failed resources.\n"
             aws cloudformation continue-update-rollback \
               --stack-name $CF_STACK_NAME \
               --resources-to-skip $FAILED_RESOURCE_IDENTIFIERS \
               --client-request-token $REQUEST_TOKEN
+            
+            echo -e "Await updates from AWS confirming rollback progress:\n"
+            STACK_STATUS=''
+            until (echo $STACK_STATUS | grep -iqP '^UPDATE_ROLLBACK_COMPLETE$');
+            do
+              STACK_STATUS=$(get_stack_status "$CF_STACK_NAME")
+              echo "The $CF_STACK_NAME stack status is: $STACK_STATUS."
+              sleep 1s
+            done
+
+            echo "The $CF_STACK_NAME stack status is: $STACK_STATUS."
+            echo -e "\nScript done."
           name: manual rollback
   deploy-lambda:
     description: "Deploys via Serverless"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,9 @@ workflows:
       - preview-development-terraform:
           requires:
             - assume-role-development
+      - fix-stack-rollback-development:
+          requires:
+            - preview-development-terraform
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           filters:


### PR DESCRIPTION
# What:
 - An attempted fix to the `UPDATE_ROLLBACK_FAILED` failure that's preventing application deployment.

# Why:
 - An old `dotnetcore3.1` runtime has been long deprecated and is no longer supported as AWS lambda runtime. As such, some internal failure related to this is happening within CloudFormation stack on something rollback related. To be able to deploy the newer runtime, this rollback issue has to be fixed separately on the affected stack.

# Notes:
 - An attempt made here is to continue with the CF stack rollback, except exclude certain resources that make it fail to rollback. In particular, this will exclude the deprecated-runtime lambda function, and will mark it off as rollback complete without actually doing a rollback.
 - Pipeline changes are temporary and will be cleaned up as part of the later clean up.

# Screenshots:

| ![image](https://github.com/user-attachments/assets/b13f92ef-20d9-4dd2-a537-46349f751af5) | ![image](https://github.com/user-attachments/assets/8d386873-be5c-4ad2-931d-9aa3788ba960) |
| --- | --- |
| **The CloudFormation failure that happens during the deployment of a newer runtime lambda** | **Error on AWS CloudFormation** |