### PR TITLE
Fix the `development Terraform infrastructure deployment not applying any changes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ jobs:
   terraform-apply-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-plan:
+      - terraform-apply:
           environment: "development"
   terraform-init-and-plan-staging:
     executor: docker-terraform


### PR DESCRIPTION
# What:
 - Point TF `development` deployment job to point to the correct CCI TF command.

# Why:
 - Currently, `development` TF infrastructure deployment is impossible due to its job pointing to TF changes preview CCI command.

# Notes:
  - Will be needed for an upcoming VPC attachment fix.