### PR TITLE
Create an outgoing traffic security groups for the listener lambda `[Pt1]`.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -38,6 +38,19 @@ terraform {
   }
 }
 
+data "aws_vpc" "housing_development_vpc" {
+  tags = {
+    Name = "housing-dev"
+  }
+}
+
+module "mtfh-reporting-data_listener_sg" {
+  source              = "../modules/security_groups/outbound_only_traffic"
+  vpc_id              = data.aws_vpc.housing_development_vpc.id
+  user_resource_name  = "mtfh-reporting-data_listener"
+  environment_name    = var.environment_name
+}
+
 # This is the parameter containing the arn of the topic to which we want to subscribe
 # This will have been created by the service the generates the events in which we are interested
 

--- a/terraform/modules/security_groups/outbound_only_traffic/main.tf
+++ b/terraform/modules/security_groups/outbound_only_traffic/main.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "outbound_traffic_sg" {
+  vpc_id = var.vpc_id
+  name_prefix = "${replace(var.user_resource_name, "/\\s+|-/", "_")}_outgoing_traffic"
+  description = "SG used to hook ${replace(var.user_resource_name, "/_|-/", " ")} lambda into VPC. No incoming traffic allowed, all outgoing traffic allowed."
+
+  egress {
+    description = "allow outbound traffic"
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # No ingress - listener does not listen to incoming traffic
+
+  tags = {
+    Name = "${replace(var.user_resource_name, "/\\s+|-/", "_")}-${var.environment_name}"
+  }
+}

--- a/terraform/modules/security_groups/outbound_only_traffic/outputs.tf
+++ b/terraform/modules/security_groups/outbound_only_traffic/outputs.tf
@@ -1,0 +1,3 @@
+output "sg_id" {
+  value = aws_security_group.outbound_traffic_sg.id
+}

--- a/terraform/modules/security_groups/outbound_only_traffic/variables.tf
+++ b/terraform/modules/security_groups/outbound_only_traffic/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {
+  description = "Id of VPC that's within AWS account being deployed to."
+  type = string
+}
+
+variable "user_resource_name" {
+  description = "Name of the resource that's going to use the security group."
+  type = string
+}
+
+variable "environment_name" {
+  description = "development/staging/production"
+  type = string
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -37,6 +37,19 @@ terraform {
   }
 }
 
+data "aws_vpc" "housing_production_vpc" {
+  tags = {
+    Name = "housing-prod"
+  }
+}
+
+module "mtfh-reporting-data_listener_sg" {
+  source              = "../modules/security_groups/outbound_only_traffic"
+  vpc_id              = data.aws_vpc.housing_production_vpc.id
+  user_resource_name  = "mtfh-reporting-data_listener"
+  environment_name    = var.environment_name
+}
+
 # This is the parameter containing the arn of the topic to which we want to subscribe
 # This will have been created by the service the generates the events in which we are interested
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -37,6 +37,19 @@ terraform {
   }
 }
 
+data "aws_vpc" "housing_staging_vpc" {
+  tags = {
+    Name = "housing-stg"
+  }
+}
+
+module "mtfh-reporting-data_listener_sg" {
+  source              = "../modules/security_groups/outbound_only_traffic"
+  vpc_id              = data.aws_vpc.housing_staging_vpc.id
+  user_resource_name  = "mtfh-reporting-data_listener"
+  environment_name    = var.environment_name
+}
+
 # This is the parameter containing the arn of the topic to which we want to subscribe
 # This will have been created by the service the generates the events in which we are interested
 


### PR DESCRIPTION
# What:
 - Create outgoing traffic security group module.
 - Create outgoing traffic security groups for each environment.

# Why:
 - To resolve the listener VPC lambda attachment errors occurring during deployment.

# Notes:
 - This PR will be succeeded by another PR that applies these security groups to the listener lambda.